### PR TITLE
fixed the service_string attribute and added retries for the push-client

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ default['push_jobs']['whitelist']   = {}
 
 case node['platform_family']
 when 'debian'
-  default['push_jobs']['service_string'] = 'runit_service[push-jobs-client]'
+  default['push_jobs']['service_string'] = 'runit_service[opscode-push-jobs-client]'
 when 'windows'
   default['push_jobs']['service_string'] = 'service[pushy-client]'
 end

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -28,8 +28,8 @@ if node['push_jobs']['package_url']
   end
 end
 
-package "push-jobs-client" do
-  if node['push_jobs']['package_url']
+if node['push_jobs']['package_url']
+  package "push-jobs-client" do
     provider Chef::Provider::Package::Dpkg
     source "#{Chef::Config[:file_cache_path]}/#{package_file}"
   end
@@ -38,6 +38,7 @@ end
 include_recipe "push-jobs::config"
 include_recipe "runit"
 
-runit_service "push-jobs-client" do
+runit_service "opscode-push-jobs-client" do
   default_logger true
+  retries 4
 end


### PR DESCRIPTION
The debian package installs as /opt/opscode-push-jobs-client and the cookbook was failing until the attribute was renamed. 

Restarting the service was exiting with a code of 1 on the first attempt to stop; adding the retries helped.
