### PR TITLE
[GH#5] Remove resource cloning.

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -80,10 +80,12 @@ package 'opscode-push-jobs-client' do
   source "#{Chef::Config[:file_cache_path]}/#{package_file}"
 end
 
-directory Chef::Config.platform_specific_path('/etc/chef') do
-  owner 'root'
-  group 'root'
-  mode 00755
+unless File.exists?(Chef::Config.platform_specific_path('/etc/chef'))
+  directory Chef::Config.platform_specific_path('/etc/chef') do
+    owner 'root'
+    group 'root'
+    mode 00755
+  end
 end
 
 template Chef::Config.platform_specific_path('/etc/chef/push-jobs-client.rb') do


### PR DESCRIPTION
This removes resource cloning if Chef::Config.platform_specific_path('/etc/chef') is already declared in another cookbook (e.g. if the user is running the chef-client cookbook which manages it).
