### PR TITLE
[HelpSpot 16632] Fully support RHEL

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ version          '1.0.0'
 # Tested on CentOS 6.4
 supports 'ubuntu'
 supports 'centos'
+supports 'rhel'
 supports 'debian'
 supports 'windows'
 

--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -47,7 +47,7 @@ else
     package_machine = node['kernel']['machine']
     package_machine = 'amd64' if package_machine == 'x86_64'
     package_file = "opscode-push-jobs-client_#{package_version}.ubuntu.#{node['platform_version']}_#{package_machine}.deb"
-  elsif platform?('centos')
+  elsif platform_family?('rhel')
     # opscode-push-jobs-client-1.0.0-1.el5.i686.rpm
     # opscode-push-jobs-client-1.0.0-1.el5.x86_64.rpm
     # opscode-push-jobs-client-1.0.0-1.el6.i686.rpm


### PR DESCRIPTION
Our friend Nathan noticed that this cookbook was not working on RHEL systems.
He tested on RHEL 6.4

http://help2.opscode.com/admin.php?pg=request&reqid=16632
