### PR TITLE
Make whitelist handling more robust

### DIFF
--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -5,7 +5,7 @@
 Chef::Config.from_file("/etc/chef/client.rb")
 
 # The whitelist comes from node['push_jobs']['whitelist']
-whitelist(<%= @whitelist.inspect %>)
+whitelist(<%= @whitelist.to_hash.inspect %>)
 
 # We're under runit, so don't output timestamp
 Mixlib::Log::Formatter.show_time = false


### PR DESCRIPTION
In testing we saw situations where the whitelist could be rendered as
the Ruby class for the attribute, which (obviously) doesn't work.

h/t @jtimberman
