### PR TITLE
Add hooks to disable SSL verification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,6 @@ group :kitchen_cloud do
   gem 'kitchen-ec2'
 end
 
-group :development_guard do
-end
-
 group :development do
   gem 'guard'
   gem 'guard-kitchen'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,9 +23,14 @@ default['push_jobs']['package_checksum']            = ''
 default['push_jobs']['package_version']             = nil
 default['push_jobs']['gem_url']                     = nil
 default['push_jobs']['gem_checksum']                = ''
-default['push_jobs']['whitelist']                   = { 'chef-client' => 'chef-client' }
+
 default['push_jobs']['config']['template_cookbook'] = nil
+default['push_jobs']['whitelist']                   = { 'chef-client' => 'chef-client' }
 default['push_jobs']['environment_variables']       = { 'LC_ALL' => 'en_US.UTF-8' }
+
+# These variables control whether we validate ssl
+default['push_jobs']['chef']['verify_api_cert']     = true
+default['push_jobs']['chef']['ssl_verify_mode']     = :verify_peer
 
 case node['platform_family']
 when 'debian', 'rhel'
@@ -39,7 +44,5 @@ when 'windows'
   default['push_jobs']['chef']['client_key_path']    = 'c:\chef\client.pem'
   default['push_jobs']['chef']['trusted_certs_path'] = 'c:\chef\trusted_certs'
 end
-
-default['push_jobs']['chef']['verify_api_cert'] = false
 
 default['push_jobs']['logging_level'] = 'info'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -45,5 +45,6 @@ template PushJobsHelper.config_path do
     trusted_certs_path: node['push_jobs']['chef']['trusted_certs_path'],
     whitelist: node['push_jobs']['whitelist'],
     env_variables: node['push_jobs']['environment_variables'],
-    verify_api_cert: node['push_jobs']['chef']['verify_api_cert'])
+    verify_api_cert: node['push_jobs']['chef']['verify_api_cert'],
+    ssl_verify_mode: node['push_jobs']['chef']['ssl_verify_mode'])
 end

--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -12,6 +12,7 @@ node_name         '<%= @node_name %>'
 client_key        '<%= @client_key_path %>'
 trusted_certs_dir '<%= @trusted_certs_path %>'
 verify_api_cert   <%= @verify_api_cert %>
+ssl_verify_mode   <%= ":#{@ssl_verify_mode}" %> 
 
 # The whitelist comes from node['push_jobs']['whitelist']
 whitelist(<%= @whitelist.to_hash.inspect %>)


### PR DESCRIPTION
For the purpose of testing we need to be able to disable SSL
checking. This adds an override to allow us to control the two ssl
verification flags 'verify_api_cert' and 'ssl_verify_mode'.

The defaults are set to full verification so this shouldn't break anything.