### PR TITLE
Allow node_name and chef_server_url to be overridden

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,10 @@ default['push_jobs']['environment_variables']       = { 'LC_ALL' => 'en_US.UTF-8
 default['push_jobs']['chef']['verify_api_cert']     = true
 default['push_jobs']['chef']['ssl_verify_mode']     = :verify_peer
 
+# These can be overridden so that we can use chef_zero based installers to set up push
+default['push_jobs']['chef']['chef_server_url']     = nil
+default['push_jobs']['chef']['node_name']           = nil
+
 # default is this comes from url, but make it overrideable
 default['push_jobs']['version']                     = nil
 

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -30,6 +30,9 @@ directory PushJobsHelper.config_dir do
   end
 end
 
+chef_server_url = node['push_jobs']['chef']['chef_server_url'] || Chef::Config.chef_server_url
+node_name = node['push_jobs']['chef']['node_name'] || Chef::Config[:node_name]
+
 template PushJobsHelper.config_path do
   source 'push-jobs-client.rb.erb'
   cookbook node['push_jobs']['config']['template_cookbook']
@@ -39,8 +42,8 @@ template PushJobsHelper.config_path do
     mode 00644
   end
   variables(
-    chef_server_url: Chef::Config.chef_server_url,
-    node_name: Chef::Config[:node_name],
+    chef_server_url: chef_server_url,
+    node_name: node_name,
     client_key_path: node['push_jobs']['chef']['client_key_path'],
     trusted_certs_path: node['push_jobs']['chef']['trusted_certs_path'],
     whitelist: node['push_jobs']['whitelist'],


### PR DESCRIPTION
It is convenient for some test systems to setup/install the client via chef-solo but have it pointed at a chef & push server instance. 