### PR TITLE
Dwm/configure logging for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ push-jobs Cookbook CHANGELOG
 ============================
 This file is used to list changes made in each version of the push-jobs cookbook.
 
+v2.6.2 (2015-11-04)
+-------------------
+- Added an attribute so we can enable timetsamps on Windows.
+
+v2.6.1 (2015-10-21)
+-------------------
+- #56 - Replaced symbols with strings in recipe
+
 v2.6.0 (2015-10-13)
 -------------------
 - Use chefdk version of berks for travis.
@@ -15,7 +23,7 @@ v2.5.0 (2015-10-06)
   especially on windows
 - #52 - More updates for newer rubocop and foodcritic
 - #50 - Allow ssl to be disabled
-- Cleanups for travis testing and general hygiene 
+- Cleanups for travis testing and general hygiene
   - test on modern ruby
   - update kitchen.yml boxes
   - bump gem versions

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,10 +36,14 @@ default['push_jobs']['chef']['ssl_verify_mode']     = :verify_peer
 default['push_jobs']['chef']['chef_server_url']     = nil
 default['push_jobs']['chef']['node_name']           = nil
 
+# Show timestamps in log by default.
+default['push_jobs']['chef']['include_timestamp']  = true
+
 case node['platform_family']
 when 'debian', 'rhel'
   default['push_jobs']['service_string']             = 'runit_service[push-jobs-client]'
   default['push_jobs']['init_style']                 = 'runit'
+  default['push_jobs']['chef']['include_timestamp']  = false
   default['push_jobs']['chef']['client_key_path']    = '/etc/chef/client.pem'
   default['push_jobs']['chef']['trusted_certs_path'] = '/etc/chef/trusted_certs'
   default['push_jobs']['chef']['install_path']       = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.6.1'
+version '2.6.2'
 
 # Tested on Ubuntu 14.04, 12.04, 10.04
 # Tested on CentOS 7.1, 6.6, 5.11

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -50,5 +50,6 @@ template PushJobsHelper.config_path do
     whitelist: node['push_jobs']['whitelist'],
     env_variables: node['push_jobs']['environment_variables'],
     verify_api_cert: node['push_jobs']['chef']['verify_api_cert'],
-    ssl_verify_mode: node['push_jobs']['chef']['ssl_verify_mode'])
+    ssl_verify_mode: node['push_jobs']['chef']['ssl_verify_mode'],
+    include_timestamp: node['push_jobs']['chef']['include_timestamp'])
 end

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -1,16 +1,41 @@
 require 'spec_helper'
 
-describe 'push-jobs::linux' do
-  cached(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
-    runner.converge('recipe[push-jobs::config]')
+describe 'push-jobs' do
+  describe '::linux' do
+    cached(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
+      runner.converge('recipe[push-jobs::config]')
+    end
+
+    it 'Creates the /etc/chef directory' do
+      expect(chef_run).to create_directory '/etc/chef'
+    end
+
+    context '/etc/chef/push-jobs-client.rb file' do
+      it 'has the expected whitelist' do
+        expect(chef_run).to render_file('/etc/chef/push-jobs-client.rb').with_content('whitelist({"chef-client"=>"chef-client"})')
+      end
+
+      it 'has timestamps disabled' do
+        expect(chef_run).to render_file('/etc/chef/push-jobs-client.rb').with_content('Mixlib::Log::Formatter.show_time = false')
+      end
+    end
   end
 
-  it 'Creates the /etc/chef directory' do
-    expect(chef_run).to create_directory '/etc/chef'
-  end
+  describe '::windows' do
+    cached(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012R2')
+      runner.converge('recipe[push-jobs::config]')
+    end
 
-  it 'Creates the /etc/chef/push-jobs-client.rb file' do
-    expect(chef_run).to render_file('/etc/chef/push-jobs-client.rb').with_content('whitelist({"chef-client"=>"chef-client"})')
+    context '/etc/chef/push-jobs-client.rb file' do
+      it 'has the expected whitelist' do
+        expect(chef_run).to render_file('/etc/chef/push-jobs-client.rb').with_content('whitelist({"chef-client"=>"chef-client"})')
+      end
+
+      it 'has timestamps disabled' do
+        expect(chef_run).to render_file('/etc/chef/push-jobs-client.rb').with_content('Mixlib::Log::Formatter.show_time = true')
+      end
+    end
   end
 end

--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -12,10 +12,10 @@ node_name         '<%= @node_name %>'
 client_key        '<%= @client_key_path %>'
 trusted_certs_dir '<%= @trusted_certs_path %>'
 verify_api_cert   <%= @verify_api_cert %>
-ssl_verify_mode   <%= ":#{@ssl_verify_mode}" %> 
+ssl_verify_mode   <%= ":#{@ssl_verify_mode}" %>
 
 # The whitelist comes from node['push_jobs']['whitelist']
 whitelist(<%= @whitelist.to_hash.inspect %>)
 
 # We're under runit, so don't output timestamp
-Mixlib::Log::Formatter.show_time = false
+Mixlib::Log::Formatter.show_time = <%= @include_timestamp %>


### PR DESCRIPTION
When running this cookbook on windows we disable timestamps in the log. This should be configurable so we can enable on environments that are not managed by runit.