### PR TITLE
Add a guard to the windows registry updater powershell_script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ push-jobs Cookbook CHANGELOG
 ============================
 This file is used to list changes made in each version of the push-jobs cookbook.
 
+v2.6.3 (2015-11-10)
+-------------------
+- Stopped the windows service from restarting with every CCR.
+
 v2.6.2 (2015-11-04)
 -------------------
 - Added an attribute so we can enable timetsamps on Windows.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default['push_jobs']['chef']['chef_server_url']     = nil
 default['push_jobs']['chef']['node_name']           = nil
 
 # Show timestamps in log by default.
-default['push_jobs']['chef']['include_timestamp']  = true
+default['push_jobs']['chef']['include_timestamp']   = true
 
 case node['platform_family']
 when 'debian', 'rhel'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.6.2'
+version '2.6.3'
 
 # Tested on Ubuntu 14.04, 12.04, 10.04
 # Tested on CentOS 7.1, 6.6, 5.11

--- a/recipes/service_windows.rb
+++ b/recipes/service_windows.rb
@@ -53,6 +53,10 @@ powershell_script 'Set the config path in the service registry key' do
       throw "ImagePath of $KeyPath has unexpected value $ImagePath"
     }
   EOH
+  not_if <<-EOH
+    $KeyPath = '#{key_path}'
+    (Get-ItemProperty -Path $KeyPath).ImagePath.Contains('#{config_file_option}')
+  EOH
   notifies :restart, "service[#{service_name}]"
 end
 


### PR DESCRIPTION
This will stop a CCR from restarting the push-jobs service every
$n minutes.