### PR TITLE
Fix version_from_manifest helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ push-jobs Cookbook CHANGELOG
 ============================
 This file is used to list changes made in each version of the push-jobs cookbook.
 
+v2.6.4 (2015-11-20)
+-------------------
+- Fix version_from_manifest helper method.
+
 v2.6.3 (2015-11-10)
 -------------------
 - Stopped the windows service from restarting with every CCR.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -84,7 +84,7 @@ module PushJobsHelper # rubocop:disable Metrics/ModuleLength
     json_path = File.join(path, 'version-manifest.json')
     txt_path = File.join(path, 'version-manifest.txt')
     version = if File.exist?(json_path)
-                JSON.parse(path)['build_version']
+                JSON.parse(IO.read(json_path))['build_version']
               elsif File.exist?(txt_path)
                 File.readlines(txt_path, 100).first.split(' ')[1]
               end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.6.3'
+version '2.6.4'
 
 # Tested on Ubuntu 14.04, 12.04, 10.04
 # Tested on CentOS 7.1, 6.6, 5.11

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require File.expand_path('libraries/helpers.rb')

--- a/spec/support/version-manifest.json
+++ b/spec/support/version-manifest.json
@@ -1,0 +1,4 @@
+{
+  "manifest_format": 1,
+  "build_version": "1.3.4"
+}

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe PushJobsHelper do
+  let(:path) { File.expand_path('spec/support') }
+
+  subject do
+    described_class
+  end
+
+  describe '.version_from_manifest' do
+    it 'returns push-jobs version from manifest' do
+      expect(subject.version_from_manifest(path)).to eq('1.3.4')
+    end
+  end
+end


### PR DESCRIPTION
Currently if we try to use the `version_from_manifest` method it is
broken, this commit fixes it and adds extra tests to verify
functionality.