### PR TITLE
Allow stable versions of >=2.0.0 push-client to be installed

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -40,17 +40,20 @@ module PushJobsHelper
   end
 
   def self.names_by_version(version, platform)
-    family =
-      if version =~ /^1\.[0-2]/
-        :family_1_0
-      elsif version =~ /^1\.3/
-        :family_1_3
-      elsif version =~ /^2\.0\.0-alpha/
-        :family_2_alpha
-      else
-        raise "No info for version '#{version}'"
-      end
+    family = family_by_version(version)
     NAMING_DATA[family][platform]
+  end
+
+  def self.family_by_version(version)
+    if version =~ /^1\.[0-2]/
+      :family_1_0
+    elsif version =~ /^1\.3/
+      :family_1_3
+    elsif version =~ /^2\.[0-1]/
+      :family_2_0
+    else
+      raise "No info for version '#{version}'"
+    end
   end
 
   def self.windows_service_name(node, version)
@@ -151,7 +154,7 @@ module PushJobsHelper
             exec_name: 'pushy-client'
           }
         },
-      family_2_alpha:
+      family_2_0:
         {
           windows: {
             package_name: 'Push Jobs Client v%{v}',

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -45,4 +45,21 @@ describe 'PushJobsHelper' do
     node = { 'push_jobs' => { 'chef' => { 'node_name' => 'Felix' } } }
     expect(PushJobsHelper.node_name(node)).to match 'Felix'
   end
+
+  describe 'family_by_version' do
+    it 'returns the family name for the corresponding version' do
+      expect(PushJobsHelper.family_by_version('1.0.0')).to eq :family_1_0
+      expect(PushJobsHelper.family_by_version('1.1.5')).to eq :family_1_0
+      expect(PushJobsHelper.family_by_version('1.3.3')).to eq :family_1_3
+      expect(PushJobsHelper.family_by_version('1.3.4')).to eq :family_1_3
+      expect(PushJobsHelper.family_by_version('2.0.0-alpha')).to eq :family_2_0
+      expect(PushJobsHelper.family_by_version('2.1.0')).to eq :family_2_0
+    end
+
+    it 'raises an error for non-recognized versions' do
+      version = '3.0.0-awesome'
+      error = "No info for version '#{version}'"
+      expect { PushJobsHelper.family_by_version(version) }.to raise_error(RuntimeError, error)
+    end
+  end
 end


### PR DESCRIPTION
### Description

This commit addresses an error that gets raised when trying to
install a non-alpha version of push-client 2.0.0 and above. This
change is necessary for the upcoming push-client release.

### Issues Resolved

An error no longer gets raised when trying to install a non-alpha 
version of push-client 2.0.0 and above.

    =====================================================================
    Error executing action `create` on resource 'template[/etc/sv/opscode-push-jobs-client/run]'
    =====================================================================

    Chef::Mixin::Template::TemplateError
    ------------------------------------
    No info for version '2.1.0'

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/runit/libraries/provider_runit_service.rb:282:in `block in <class:RunitService>'

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/runit/libraries/provider_runit_service.rb

    82:           template "#{sv_dir_name}/run" do
    83:             owner new_resource.owner unless new_resource.owner.nil?
    84:             group new_resource.group unless new_resource.group.nil?
    85:             source "sv-#{new_resource.run_template_name}-run.erb"
    86:             cookbook template_cookbook
    87:             mode '0755'
    88:             variables(options: new_resource.options)
    89:             action :create
    90:             notifies :run, 'ruby_block[restart_service]', :delayed
    91:           end
    92:

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/runit/libraries/provider_runit_service.rb:82:in `block in <class:RunitService>'

    template("/etc/sv/opscode-push-jobs-client/run") do
     action [:create]
     retries 0
     retry_delay 2
     default_guard_interpreter :default
     source "sv-opscode-push-jobs-client-run.erb"
     cookbook "push-jobs"
     variables {:options=>{"logging_level"=>"info", "node"=>{"push_jobs"=>{"package_url"=>"http://scottopherson.s3.amazonaws.com/push-jobs-client_2.1.0-1_amd64.deb", "package_checksum"=>"1404dbae510863b214782b8189b3de011c76e24f792652355a63c5d0f546471e", "package_version"=>nil, "gem_url"=>nil, "gem_checksum"=>"", "config"=>{"template_cookbook"=>nil}, "whitelist"=>{"chef-client"=>"chef-client"}, "environment_variables"=>{"LC_ALL"=>"en_US.UTF-8"}, "chef"=>{"verify_api_cert"=>false, "ssl_verify_mode"=>"verify_none", "chef_server_url"=>nil, "node_name"=>nil, "include_timestamp"=>false, "client_key_path"=>"/etc/chef/client.pem", "trusted_certs_path"=>"/etc/chef/trusted_certs", "install_path"=>nil, "exec_name"=>nil}, "service_string"=>"runit_service[push-jobs-client]", "init_style"=>"runit", "logging_level"=>"info"}}, "config"=>"/etc/chef/push-jobs-client.rb"}}
     declared_type :template
     cookbook_name "push-jobs"
     mode "0755"
     atomic_update true
     path "/etc/sv/opscode-push-jobs-client/run"
    end

    Template Context:
    -----------------
    on line #3
     1: #!/bin/sh
     2: exec 2>&1
     3: exec <%= PushJobsHelper.linux_install_path(@options['node']) %>/bin/<%= PushJobsHelper.linux_exec_name(@options['node']) %> -l <%= @options['logging_level'] %> <% if @options['config'] -%> -c <%= @options['config'] %> <% end -%>

    Platform:
    ---------
    x86_64-linux

### Check List
- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed.