### PR TITLE
Try a compatible package for a non-suported platform

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.7.0'
+version '2.7.1'
 
 # Tested on Ubuntu 14.04, 12.04
 # Tested on CentOS 7.2, 6.7

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -44,6 +44,7 @@ end
 chef_ingredient 'push-jobs-client' do
   version package_version || node['push_jobs']['package_version']
   package_source "#{Chef::Config[:file_cache_path]}/#{package_file}" if package_url
+  platform_version_compatibility_mode true
 end
 
 include_recipe 'push-jobs::config'


### PR DESCRIPTION
### Description

push-jobs should try a compatible package for a platform when it doesn't find an exact match (so install RHEL 6 instead of RHEL 7 if it can't find the RHEL 7 package - in 99% of cases this will just work).

### Issues Resolved

None

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


