### PR TITLE
Avoid potential runit cookbook failures on RHEL

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -9,9 +9,6 @@ transport:
 provisioner:
   name: dokken
 
-verifier:
-  name: inspec
-
 platforms:
 - name: debian-7
   driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,6 +37,15 @@ suites:
         environment_variables: {LC_ALL: "en_US.UTF-8"}
         allow_unencrypted: true
     excludes: windows-2012r2
+  - name: one_oh
+    run_list: recipe[push-jobs]
+    attributes:
+      push_jobs:
+        whitelist: {chef-client: "chef-client"}
+        environment_variables: {LC_ALL: "en_US.UTF-8"}
+        allow_unencrypted: true
+        package_version: 1.3.4
+    excludes: windows-2012r2
   - name: windows
     run_list: recipe[push-jobs]
     includes: windows-2012r2

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ supports 'debian'
 supports 'windows'
 
 # For per-platform resources, respectively
-depends 'runit'
+depends 'runit', '>= 1.2.0'
 depends 'windows'
 depends 'chef-ingredient', '>= 0.18.0'
 


### PR DESCRIPTION
### Description

Require a version of runit cookbook that supports RHEL

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

