### PR TITLE
Fails to enable systems service to start on boot

### DIFF
--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -46,7 +46,7 @@ action :stop do
   service 'chef-push-jobs-client' do
     supports status: true
     action :stop
-    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs.service') }
+    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs-client.service') }
   end
 end
 
@@ -61,7 +61,7 @@ action :disable do
   service 'chef-push-jobs-client' do
     supports status: true
     action :disable
-    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs.service') }
+    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs-client.service') }
   end
 end
 
@@ -71,7 +71,7 @@ action :enable do
   service 'chef-push-jobs-client' do
     supports status: true
     action :enable
-    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs.service') }
+    only_if { ::File.exist?('/etc/systemd/system/chef-push-jobs-client.service') }
     subscribes :restart, "template[#{PushJobsHelper.config_path}]"
   end
 end


### PR DESCRIPTION
### Description

There is a typo in the resource that prevents the chef-push-jobs-client systemd service from being enabled to start on boot
