### PR TITLE
adding log location setting

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,4 @@ when 'windows'
 end
 
 default['push_jobs']['logging_level'] = 'info'
+default['push_jobs']['logging_dir'] = '/var/log/chef'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -134,7 +134,7 @@ module PushJobsHelper
   end
 
   def self.cli_command(node)
-    "#{PushJobsHelper.linux_install_path(node)}/bin/#{PushJobsHelper.linux_exec_name(node)} -l #{node['push_jobs']['logging_level']} -c #{PushJobsHelper.config_path}"
+    "#{PushJobsHelper.linux_install_path(node)}/bin/#{PushJobsHelper.linux_exec_name(node)} -l #{node['push_jobs']['logging_level']} -L #{node['push_jobs']['logging_dir']}/push-jobs-client.log -c #{PushJobsHelper.config_path}"
   end
 
   NAMING_DATA ||=

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -30,6 +30,16 @@ directory PushJobsHelper.config_dir do
   end
 end
 
+directory node['push_jobs']['logging_dir'] do
+  unless platform_family?('windows')
+    owner 'root'
+    group 'root'
+    mode 00755
+    recursive true
+    not_if { node['push_jobs']['logging_dir'].nil? }
+  end
+end
+
 # Next refactor:  generate config from chef-ingredient.
 template PushJobsHelper.config_path do
   source 'push-jobs-client.rb.erb'


### PR DESCRIPTION
### Description

Push-job-client doesn't generate logs under /var/log/push-jobs-client/current anymore.
need to pass the log location path through a daemon option.