### PR TITLE
adding log location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The connection information for the push server is established when the push serv
 
 ## Verify Push Jobs Client Connection
 
-If the push client has been successfully installed on a node, the client should be able to successfully respond to a `knife job` directed to the node. If the node is not responding correctly, please consult the logs `/var/log/push-jobs-client/current` (for Debian and Rhel families) and look for entries similar to the following:
+If the push client has been successfully installed on a node, the client should be able to successfully respond to a `knife job` directed to the node. If the node is not responding correctly, please consult the logs `node['push_jobs']['logging_dir']/push-jobs-client.log (default: /var/log/chef/push-jobs-client.log)` (for Debian and Rhel families) and look for entries similar to the following:
 
 ```
 INFO: [pclient] Starting client ...

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,4 @@ when 'windows'
 end
 
 default['push_jobs']['logging_level'] = 'info'
+default['push_jobs']['logging_dir'] = '/var/log/chef'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -134,7 +134,7 @@ module PushJobsHelper
   end
 
   def self.cli_command(node)
-    "#{PushJobsHelper.linux_install_path(node)}/bin/#{PushJobsHelper.linux_exec_name(node)} -l #{node['push_jobs']['logging_level']} -c #{PushJobsHelper.config_path}"
+    "#{PushJobsHelper.linux_install_path(node)}/bin/#{PushJobsHelper.linux_exec_name(node)} -l #{node['push_jobs']['logging_level']} -L #{node['push_jobs']['logging_dir']}/push-jobs-client.log -c #{PushJobsHelper.config_path}"
   end
 
   NAMING_DATA ||=

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -30,6 +30,16 @@ directory PushJobsHelper.config_dir do
   end
 end
 
+directory node['push_jobs']['logging_dir'] do
+  unless platform_family?('windows')
+    owner 'root'
+    group 'root'
+    mode 00755
+    recursive true
+    not_if { node['push_jobs']['logging_dir'].nil? }
+  end
+end
+
 # Next refactor:  generate config from chef-ingredient.
 template PushJobsHelper.config_path do
   source 'push-jobs-client.rb.erb'


### PR DESCRIPTION
### Description

Logs are not generated under /var/log. it seems to require -L option in daemon startup options.
### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable 
- [X] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Signed-off-by: akadoya aoi.kadoya@rakops.com
