### PR TITLE
Typo preventing berks upload

### DIFF
--- a/test/integration/windows/windows_spec.rb
+++ b/test/integration/windows/windows_spec.rb
@@ -2,6 +2,7 @@ describe 'chef-push-jobs package' do
   it 'Installs the push jobs client' do
     expect(file 'C:/opscode/pushy/bin/pushy-client.bat').to be_file
   end
+end
 
 describe 'push client service' do
   it 'should enable and start service' do


### PR DESCRIPTION
### Description

Get a ruby compile error trying to `berks vendor && berks upload`

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
