### PR TITLE
Set logging_dir per platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,7 @@ when 'debian', 'rhel'
   default['push_jobs']['chef']['trusted_certs_path'] = '/etc/chef/trusted_certs'
   default['push_jobs']['chef']['install_path']       = nil
   default['push_jobs']['chef']['exec_name']          = nil
+  default['push_jobs']['logging_dir']                = '/var/log/chef'
 when 'windows'
   default['push_jobs']['service_string']             = 'service[push-jobs-client]'
   default['push_jobs']['init_style']                 = 'windows'
@@ -58,7 +59,7 @@ when 'windows'
   default['push_jobs']['service_name']               = nil
   default['push_jobs']['chef']['client_key_path']    = 'c:\chef\client.pem'
   default['push_jobs']['chef']['trusted_certs_path'] = 'c:\chef\trusted_certs'
+  default['push_jobs']['logging_dir']                = 'c:\chef\log'
 end
 
 default['push_jobs']['logging_level'] = 'info'
-default['push_jobs']['logging_dir'] = '/var/log/chef'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.1'
+version '4.0.2'
 
 # Tested on Ubuntu 12.04 - 16.04
 # Tested on CentOS 6-7


### PR DESCRIPTION
Signed-off-by: Matt Kulka <mkulka@parchment.com>

### Description

Sets `node['push_jobs']['logging_dir']` per platform instead of a static Unix path.

### Issues Resolved

Fixes #113 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
