### PR TITLE
Default to :latest version of push jobs (Chef 13 fix)

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -49,7 +49,7 @@ end
 # This uses packages.chef.io by default.
 #
 chef_ingredient 'push-jobs-client' do
-  version package_version || node['push_jobs']['package_version']
+  version package_version || node['push_jobs']['package_version'] || :latest
   package_source local_package_path if defined?(local_package_path)
   platform_version_compatibility_mode true
 end


### PR DESCRIPTION
### Description

If you don't specify a version, it defaults to 'nil'. Until chef 13,
this wasn't a problem, as it would result in the resource's default
value of :latest being used. However, in Chef 13, this results in the
version literally being set to nil, causing an error.

This change simply adds :latest as an explicit fallback option when
setting the version to install.

<https://docs.chef.io/deprecations_custom_resource_cleanups.html#nil-properties> is the link to the deprecation, although it appears the issue addressed in this PR is slightly different, but results in the same warning and error.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
