### PR TITLE
Fix issue #123: installation failure on CentOS 6

### DIFF
--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -42,7 +42,7 @@ get_pid() {
 }
 
 is_running() {
-    [ -f "$PID_FILE" ] && ps $PID_FILE > /dev/null 2>&1
+    [ -f "$PID_FILE" ] && ps p `cat $PID_FILE` > /dev/null 2>&1
 }
 
 case "$1" in
@@ -51,7 +51,7 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $NAME"
-        $SU -c "<%= @cli_command %>"
+        $SU -c "<%= @cli_command %>" &> /dev/null &
         echo $! > "$PID_FILE"
         if ! is_running; then
             echo "Unable to start, check the logs <%= @log_dir %>."
@@ -84,7 +84,7 @@ case "$1" in
             if [ -f "$PID_FILE" ]; then
                 rm "$PID_FILE"
             fi
-            if [-f "$LOCK_DIR/$NAME"]; then
+            if [ -f "$LOCK_DIR/$NAME" ]; then
             	rm "$LOCK_DIR/$NAME"
             fi
         fi


### PR DESCRIPTION
### Description

- Fix installation failure on CentOS 6 because the daemon not started in background
- Fix bash syntax error on line 87

### Issues Resolved
https://github.com/chef-cookbooks/push-jobs/issues/123

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
