### PR TITLE
make sysvinit default for rhel <= 6

### DIFF
--- a/resources/service_sysvinit.rb
+++ b/resources/service_sysvinit.rb
@@ -13,7 +13,7 @@ provides :push_jobs_service, platform: 'debian' do |node|
 end
 
 provides :push_jobs_service, platform_family: 'rhel' do |node|
-  node['platform_version'].to_i == 6
+  node['platform_version'].to_i <= 6
 end
 
 action :start do


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Description
Make sysvinit style service default for RHEL/CentOS <= 6

The reality is that there are still some customers who are paying for extended life support of RHEL 5.
This change is a minimum compromise to allow those to use push-jobs cookbook with SysVinit style service.


### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>