### PR TITLE
Fix GH-128 - default recipe fails on Amazon Linux with Chef 13

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -72,3 +72,12 @@ platforms:
   driver:
     image: opensuse:leap
     pid_one_command: /bin/systemd
+
+- name: amazon-2017.03
+  driver:
+    image: amazonlinux:2017.03
+    platform: rhel
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install which initscripts sudo
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,7 @@ default['push_jobs']['chef']['node_name']           = nil
 default['push_jobs']['chef']['include_timestamp']   = true
 
 case node['platform_family']
-when 'debian', 'rhel'
+when 'debian', 'rhel', 'amazon'
   default['push_jobs']['init_style']                 = nil # auto detect based on system
   default['push_jobs']['chef']['include_timestamp']  = false
   default['push_jobs']['chef']['client_key_path']    = '/etc/chef/client.pem'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.1.7'
+version '5.1.1'
 
 supports 'ubuntu'
 supports 'centos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,12 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the Chef Push Jobs Client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.1.1'
+version '5.1.7'
 
 supports 'ubuntu'
 supports 'centos'
 supports 'debian'
+supports 'amazon'
 supports 'windows'
 
 depends 'runit', '>= 1.2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ unless node['push_jobs']['whitelist'].is_a? Hash
 end
 
 case node['platform_family']
-when 'windows', 'debian', 'rhel'
+when 'windows', 'debian', 'rhel', 'amazon'
   include_recipe 'push-jobs::install'
 else
   raise 'This cookbook currently supports only Windows, Debian-family Linux, and RHEL-family Linux.'

--- a/resources/service_sysvinit.rb
+++ b/resources/service_sysvinit.rb
@@ -16,8 +16,6 @@ provides :push_jobs_service, platform_family: 'rhel' do |node|
   node['platform_version'].to_i == 6
 end
 
-provides :push_jobs_service, platform_family: 'amazon'
-
 action :start do
   delete_runit
   create_init

--- a/resources/service_sysvinit.rb
+++ b/resources/service_sysvinit.rb
@@ -16,6 +16,8 @@ provides :push_jobs_service, platform_family: 'rhel' do |node|
   node['platform_version'].to_i == 6
 end
 
+provides :push_jobs_service, platform_family: 'amazon'
+
 action :start do
   delete_runit
   create_init

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -24,6 +24,8 @@ provides :push_jobs_service, platform: 'ubuntu' do |node|
   node['platform_version'].to_f < 15.10
 end
 
+provides :push_jobs_service, platform: 'amazon'
+
 action :start do
   delete_runit
   create_init

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -31,6 +31,7 @@ action :start do
   create_init
 
   service 'chef-push-jobs-client' do
+    provider Chef::Provider::Service::Upstart
     supports restart: true, status: true
     action :start
     subscribes :restart, "template[#{PushJobsHelper.config_path}]"
@@ -39,6 +40,7 @@ end
 
 action :stop do
   service 'chef-push-jobs-client' do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :stop
     only_if { ::File.exist?('/etc/init/chef-push-jobs-client.conf') }
@@ -47,6 +49,7 @@ end
 
 action :restart do
   service 'chef-push-jobs-client' do
+    provider Chef::Provider::Service::Upstart
     supports restart: true, status: true
     action :restart
   end
@@ -56,6 +59,7 @@ action :enable do
   create_init
 
   service 'chef-push-jobs-client' do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :enable
     only_if { ::File.exist?('/etc/init/chef-push-jobs-client.conf') }
@@ -65,6 +69,7 @@ end
 
 action :disable do
   service 'chef-push-jobs-client' do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :disable
     only_if { ::File.exist?('/etc/init/chef-push-jobs-client.conf') }
@@ -77,6 +82,7 @@ action_class do
 
     # service resource for notification
     service 'chef-push-jobs-client' do
+      provider Chef::Provider::Service::Upstart
       action :nothing
     end
 

--- a/test/integration/default/linux_spec.rb
+++ b/test/integration/default/linux_spec.rb
@@ -15,7 +15,7 @@ describe file('/etc/chef/push-jobs-client.rb') do
   its('content') { should match /allow_unencrypted false/ }
 end
 
-if os.redhat? || os.debian? 
+if os.redhat? || os.debian? || os[:family] == 'amazon'
   describe service('chef-push-jobs-client') do
     it { should be_enabled }
     it { should be_running }


### PR DESCRIPTION
### Description

This PR adds Amazon Linux support to this cookbook for Chef 13.  On Chef 12, the `platform_family` for that distribution was "rhel", so it worked without modification.

I chose to use Upstart as the init service, as this has been used by Amazon Linux for a number of years.  To make this work, I had to explicitly specify the service provider within `service_upstart.rb` as Chef 13 is selecting the sysvinit provider on that distribution.  This looks a little gross, but should not change behaviour for any other distribution.

I added an Amazon Linux suite to the kitchen-dokken configuration to work through these issues, but I'm not sure whether it's appropriate to add that in this PR as it isn't a supported platform for push-jobs (the contribution guidelines didn't give any hints).

Credit to @donone-apex for the initial commit in this PR, and motivation for finishing it.  I'm happy for him to cherry-pick the commits in this branch if the preference is to instead complete the [WIP PR 127](https://github.com/chef-cookbooks/push-jobs/pull/127).

### Issues Resolved

https://github.com/chef-cookbooks/push-jobs/issues/128

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>