### PR TITLE
Sles 11 support

### DIFF
--- a/resources/service_sysvinit.rb
+++ b/resources/service_sysvinit.rb
@@ -11,6 +11,10 @@ provides :push_jobs_service, platform: 'debian' do |node|
   node['platform_version'].to_i == 7
 end
 
+provides :push_jobs_service, platform: 'suse' do |node|
+  node['platform_version'].to_f <= 11.4
+end
+
 action :start do
   delete_runit
   create_init
@@ -77,6 +81,7 @@ action_class do
         lock_dir: platform_lock_dir,
         log_dir: "#{node['push_jobs']['logging_dir']}/push-jobs-client.log"
       )
+      notifies :restart, 'service[chef-push-jobs-client]', :immediately
     end
   end
 

--- a/resources/service_sysvinit.rb
+++ b/resources/service_sysvinit.rb
@@ -12,7 +12,7 @@ provides :push_jobs_service, platform: 'debian' do |node|
 end
 
 provides :push_jobs_service, platform: 'suse' do |node|
-  node['platform_version'].to_f <= 11.4
+  node['platform_version'].to_i < 12
 end
 
 action :start do

--- a/spec/unit/recipes/service_spec.rb
+++ b/spec/unit/recipes/service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_context 'chef run' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform_details)
+    runner.node.normal['push_jobs']['package_url'] = pkg_url
+    runner.converge(described_recipe)
+  end
+end
+
+shared_examples 'creates push-jobs service' do
+  it 'will enable the push_jobs_service resource' do
+    expect(chef_run).to enable_push_jobs_service('push-jobs')
+  end
+  it 'will start the push_jobs_service resource' do
+    expect(chef_run).to start_push_jobs_service('push-jobs')
+  end
+  it 'will include the push-jobs::package recipe' do
+    expect(chef_run).to include_recipe('push-jobs::package')
+  end
+  it 'will create the push-jobs client service file' do
+    expect(chef_run).to create_template(service_file)
+  end
+  it 'restats the push-jobs service' do
+    t = chef_run.template(service_file)
+    expect(t).to notify('service[chef-push-jobs-client]').to(:restart).immediately
+  end
+end
+
+shared_examples 'calls the push-jobs service systemd resource' do
+  it 'reloads the systemd service' do
+    template = chef_run.template(service_file)
+    expect(template).to notify('execute[reload_unit_file]').to(:run).immediately
+  end
+end
+
+describe 'push-jobs::service' do
+
+  context 'when platform is suse version 11.4' do
+    let(:platform_details) do
+      { platform: 'suse', version: '11.4', step_into: 'push_jobs_service' }
+    end
+    let(:pkg_url) { 'http://foo.bar.com/push-jobs-client-2.4.5-1.x86_64.rpm' }
+    let(:service_file) { '/etc/init.d/chef-push-jobs-client' }
+    include_context 'chef run'
+    include_examples 'creates push-jobs service'
+  end
+
+  context 'when platform is suse version 12.3' do
+    let(:platform_details) do
+      { platform: 'suse', version: '12.3', step_into: 'push_jobs_service' }
+    end
+    let(:pkg_url) { 'http://foo.bar.com/push-jobs-client_2.4.5-1.x86_64.rpm' }
+    let(:service_file) { '/etc/systemd/system/chef-push-jobs-client.service' }
+    include_context 'chef run'
+    include_examples 'creates push-jobs service'
+    include_examples 'calls the push-jobs service systemd resource'
+  end
+end

--- a/spec/unit/recipes/service_spec.rb
+++ b/spec/unit/recipes/service_spec.rb
@@ -37,7 +37,6 @@ shared_examples 'calls the push-jobs service systemd resource' do
 end
 
 describe 'push-jobs::service' do
-
   context 'when platform is suse version 11.4' do
     let(:platform_details) do
       { platform: 'suse', version: '11.4', step_into: 'push_jobs_service' }


### PR DESCRIPTION
Signed-off-by: Steve Brown <sbrown@chef.io>

### Description

Allows installation of push jobs client on sles 11
The commit makes sure that the sysvinit resource is uses for sles 11 systems.
Previously it tried to use the runit service resource, this would fail as the runit cookbook does not support suse.

### Issues Resolved

No issue related to this but it has been requested by a customer

### Check List

- [ x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
