### PR TITLE
add proxy configuration support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,16 @@ default['push_jobs']['chef']['node_name']           = nil
 # Show timestamps in log by default.
 default['push_jobs']['chef']['include_timestamp']   = true
 
+# Forward proxy configuration, url and optional user/pass for each http and https protocol
+default['push_jobs']['proxy']['http']['url'] = nil
+default['push_jobs']['proxy']['http']['user'] = nil
+default['push_jobs']['proxy']['http']['pass'] = nil
+default['push_jobs']['proxy']['https']['url'] = nil
+default['push_jobs']['proxy']['https']['user'] = nil
+default['push_jobs']['proxy']['https']['pass'] = nil
+# Domains or suffixes to bypass proxy usage
+default['push_jobs']['no_proxy'] = nil
+
 case node['platform_family']
 when 'debian', 'rhel', 'suse', 'amazon'
   default['push_jobs']['init_style']                 = nil # auto detect based on system

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -130,6 +130,8 @@ module PushJobsHelper
       'verify_api_cert' => node['push_jobs']['chef']['verify_api_cert'],
       'ssl_verify_mode' => node['push_jobs']['chef']['ssl_verify_mode'],
       'include_timestamp' => node['push_jobs']['chef']['include_timestamp'],
+      'proxy' => node['push_jobs']['proxy'],
+      'no_proxy' => node['push_jobs']['no_proxy'],
     }
   end
 

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -1,12 +1,63 @@
 require 'spec_helper'
 
 describe 'push-jobs' do
+  shared_examples_for 'has common configuration' do
+    it 'has the specified environment variables' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("LC_ALL=\'en_US.UTF-8\'")
+    end
+
+    it 'has the specified chef server url' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("chef_server_url   \'https://chefserver.mycorp.co\'")
+    end
+
+    it 'has the specified verify_api_cert entry' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('verify_api_cert   true')
+    end
+
+    it 'has the specified ssl_verify_mode' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('ssl_verify_mode   :verify_peer')
+    end
+
+    it 'has the expected whitelist' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('whitelist({"chef-client"=>"chef-client"})')
+    end
+
+    it 'has allow_unencrypted set to true when attribute set' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('allow_unencrypted true')
+    end
+  end
+
+  shared_examples_for 'has proxy configuration' do
+    it 'has an http proxy configured' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('http_proxy \'http://proxy.mycorp.co\'')
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('http_proxy_user \'foo\'')
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('http_proxy_pass \'bar\'')
+    end
+
+    it 'has an https proxy configured' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('https_proxy \'https://proxy.mycorp.co\'')
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('https_proxy_user \'biz\'')
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('https_proxy_pass \'baz\'')
+    end
+
+    it 'has no proxy configured' do
+      expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('no_proxy \'127.0.0.1\'')
+    end
+  end
+
   describe '::install' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
       runner.node.normal['push_jobs']['chef']['node_name'] = 'Oscar'
       runner.node.normal['push_jobs']['chef']['chef_server_url'] = 'https://chefserver.mycorp.co'
       runner.node.normal['push_jobs']['allow_unencrypted'] = true
+      runner.node.normal['push_jobs']['proxy']['http']['url'] = 'http://proxy.mycorp.co'
+      runner.node.normal['push_jobs']['proxy']['http']['user'] = 'foo'
+      runner.node.normal['push_jobs']['proxy']['http']['pass'] = 'bar'
+      runner.node.normal['push_jobs']['proxy']['https']['url'] = 'https://proxy.mycorp.co'
+      runner.node.normal['push_jobs']['proxy']['https']['user'] = 'biz'
+      runner.node.normal['push_jobs']['proxy']['https']['pass'] = 'baz'
+      runner.node.normal['push_jobs']['no_proxy'] = '127.0.0.1'
       runner.converge('recipe[push-jobs::config]')
     end
 
@@ -17,14 +68,6 @@ describe 'push-jobs' do
     end
 
     context '/etc/chef/push-jobs-client.rb file' do
-      it 'has the specified environment variables' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("LC_ALL=\'en_US.UTF-8\'")
-      end
-
-      it 'has the specified chef server url' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("chef_server_url   \'https://chefserver.mycorp.co\'")
-      end
-
       it 'has the specified node name' do
         expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("node_name         \'Oscar\'")
       end
@@ -37,25 +80,12 @@ describe 'push-jobs' do
         expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("trusted_certs_dir \'/etc/chef/trusted_certs\'")
       end
 
-      it 'has the specified verify_api_cert entry' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('verify_api_cert   true')
-      end
-
-      it 'has the specified ssl_verify_mode' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('ssl_verify_mode   :verify_peer')
-      end
-
-      it 'has the specified whitelist' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('whitelist({"chef-client"=>"chef-client"})')
-      end
-
       it 'has timestamps disabled' do
         expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('Mixlib::Log::Formatter.show_time = false')
       end
 
-      it 'has allow_unencrypted set to true when attribute set' do
-        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('allow_unencrypted true')
-      end
+      it_behaves_like 'has common configuration'
+      it_behaves_like 'has proxy configuration'
     end
   end
 
@@ -63,57 +93,43 @@ describe 'push-jobs' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '2012R2')
       runner.node.normal['push_jobs']['chef']['node_name'] = 'Felix'
-      runner.node.normal['push_jobs']['chef']['chef_server_url'] = 'https://mychefserver.mycorp.co'
+      runner.node.normal['push_jobs']['chef']['chef_server_url'] = 'https://chefserver.mycorp.co'
       runner.node.normal['push_jobs']['allow_unencrypted'] = true
+      runner.node.normal['push_jobs']['proxy']['http']['url'] = 'http://proxy.mycorp.co'
+      runner.node.normal['push_jobs']['proxy']['http']['user'] = 'foo'
+      runner.node.normal['push_jobs']['proxy']['http']['pass'] = 'bar'
+      runner.node.normal['push_jobs']['proxy']['https']['url'] = 'https://proxy.mycorp.co'
+      runner.node.normal['push_jobs']['proxy']['https']['user'] = 'biz'
+      runner.node.normal['push_jobs']['proxy']['https']['pass'] = 'baz'
+      runner.node.normal['push_jobs']['no_proxy'] = '127.0.0.1'
       runner.converge('recipe[push-jobs::config]')
     end
 
-    before { @config_dir_win = Chef::Config.platform_specific_path('/etc/chef') }
+    before { @config_dir = Chef::Config.platform_specific_path('/etc/chef') }
 
     it 'Creates the /etc/chef directory in Windows' do
-      expect(chef_run).to create_directory(@config_dir_win)
+      expect(chef_run).to create_directory(@config_dir)
     end
 
     context 'C:\chef\push-jobs-client.rb file' do
-      it 'has the specified environment variables' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content("LC_ALL=\'en_US.UTF-8\'")
-      end
-
-      it 'has the specified chef server url' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content("chef_server_url   \'https://mychefserver.mycorp.co\'")
-      end
-
       it 'has the specified node name' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content("node_name         \'Felix\'")
+        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("node_name         \'Felix\'")
       end
 
       it 'has the specified client key' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content("client_key        \'C\:\\chef\\client.pem\'")
+        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("client_key        \'C\:\\chef\\client.pem\'")
       end
 
       it 'has the specified trusted certs entry' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content("trusted_certs_dir \'C\:\\chef\\trusted_certs\'")
+        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content("trusted_certs_dir \'C\:\\chef\\trusted_certs\'")
       end
 
-      it 'has the specified verify_api_cert entry' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content('verify_api_cert   true')
+      it 'has timestamps enabled' do
+        expect(chef_run).to render_file("#{@config_dir}/push-jobs-client.rb").with_content('Mixlib::Log::Formatter.show_time = true')
       end
 
-      it 'has the specified ssl_verify_mode' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content('ssl_verify_mode   :verify_peer')
-      end
-
-      it 'has the expected whitelist' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content('whitelist({"chef-client"=>"chef-client"})')
-      end
-
-      it 'has timestamps disabled' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content('Mixlib::Log::Formatter.show_time = true')
-      end
-
-      it 'has allow_unencrypted set to true when attribute set' do
-        expect(chef_run).to render_file("#{@config_dir_win}/push-jobs-client.rb").with_content('allow_unencrypted true')
-      end
+      it_behaves_like 'has common configuration'
+      it_behaves_like 'has proxy configuration'
     end
   end
 end

--- a/templates/push-jobs-client.rb.erb
+++ b/templates/push-jobs-client.rb.erb
@@ -15,6 +15,19 @@ verify_api_cert   <%= @verify_api_cert %>
 ssl_verify_mode   <%= ":#{@ssl_verify_mode}" %>
 allow_unencrypted <%= @allow_unencrypted %>
 
+<% @proxy.keys.each do |proto|
+     next if @proxy[proto]['url'].nil? -%>
+<%= proto %>_proxy '<%= @proxy[proto]['url'] %>'
+<%   %w[user pass].each do |key|
+       if @proxy[proto][key] -%>
+<%= proto %>_proxy_<%= key %> '<%= @proxy[proto][key] %>'
+<%     end -%>
+<%   end -%>
+<% end -%>
+<% unless @no_proxy.nil? -%>
+no_proxy '<%= @no_proxy %>'
+<% end -%>
+
 # The whitelist comes from node['push_jobs']['whitelist']
 whitelist(<%= @whitelist.to_hash.inspect %>)
 


### PR DESCRIPTION
### Description

This pull adds explicit proxy configuration for push-jobs-client. While undocumented, setting the same
attributes in the config file as chef-client for proxies (e.g. `http_proxy`, `https_proxy`, etc.) does work
for pushy-client. This configuration can be configured via the `node['push_jobs']['proxy']['http']` and
`node['push_jobs']['proxy']['https']` hashes. `node['push_jobs']['no_proxy']` string attribute can also
be specified for which domains/suffixes are to be proxy bypassed.

### Issues Resolved

Fixes #79

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Matt Kulka <mkulka@parchment.com>