### PR TITLE
Upgrade the push-jobs client if a newer package is available

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -53,4 +53,5 @@ chef_ingredient 'push-jobs-client' do
   version package_version if package_version
   package_source local_package_path if local_package_path
   platform_version_compatibility_mode true
+  action :upgrade
 end


### PR DESCRIPTION
Fixes #119

Even when specifying a package via attributes with a version, shasum, and URL, if push jobs is already installed it won't be upgraded. This change will upgrade to the latest version available, which we generally want. Rather than adding a flag to enable upgrades, users can opt-out by specifying a specific package using the existing attributes.