### PR TITLE
Added file_dir attribute used by the config template of the push client.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,7 @@ when 'debian', 'rhel', 'suse', 'amazon'
   default['push_jobs']['chef']['install_path']       = nil
   default['push_jobs']['chef']['exec_name']          = nil
   default['push_jobs']['logging_dir']                = '/var/log/chef'
+  default['push_jobs']['file_dir']                   = '/tmp/pushy'
 when 'windows'
   default['push_jobs']['service_string']             = 'service[push-jobs-client]'
   default['push_jobs']['logging_dir']                = nil
@@ -70,6 +71,7 @@ when 'windows'
   default['push_jobs']['chef']['client_key_path']    = 'C:\chef\client.pem'
   default['push_jobs']['chef']['trusted_certs_path'] = 'C:\chef\trusted_certs'
   default['push_jobs']['logging_dir']                = 'C:\chef\log'
+  default['push_jobs']['file_dir']                   = 'C:\chef\pushy'
 end
 
 default['push_jobs']['logging_level'] = 'info'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -132,6 +132,7 @@ module PushJobsHelper
       'include_timestamp' => node['push_jobs']['chef']['include_timestamp'],
       'proxy' => node['push_jobs']['proxy'],
       'no_proxy' => node['push_jobs']['no_proxy'],
+      'file_dir' => node['push_jobs']['file_dir'],
     }
   end
 

--- a/templates/push-jobs-client.rb.erb
+++ b/templates/push-jobs-client.rb.erb
@@ -10,6 +10,7 @@
 chef_server_url   '<%= @chef_server_url %>'
 node_name         '<%= @node_name %>'
 client_key        '<%= @client_key_path %>'
+file_dir          '<%= @file_dir %>'
 trusted_certs_dir '<%= @trusted_certs_path %>'
 verify_api_cert   <%= @verify_api_cert %>
 ssl_verify_mode   <%= ":#{@ssl_verify_mode}" %>


### PR DESCRIPTION
Added file_dir attribute used by the config template of the push client.

Obvious fix.

### Description

Added new file_dir attribute that specifies the location of the files on the remote node that are stored by the push job.  Part of the push client issue fix that affects windows nodes.

### Issues Resolved

Related to issue [169](https://github.com/chef/opscode-pushy-client/issues/169) of the pushy client.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
